### PR TITLE
Update 02-workflow-events.yaml - Pull_request trigger - GHA

### DIFF
--- a/.github/workflows/02-workflow-events.yaml
+++ b/.github/workflows/02-workflow-events.yaml
@@ -1,8 +1,8 @@
 name: 02 - Workflow Events
-on: push
+on: [push, pull_request]
 jobs:
-  name: echo
-  runs-on: ubuntu-latest
+  echo:
+    runs-on: ubuntu-latest
     steps:
       - name: Show the Trigger
         run: echo "Event name: ${{ github.event_name }}"


### PR DESCRIPTION
fixed the issue for 02 workflow. The job name doesn't start with a name keyword. It starts with just the name and then the runs-on and steps comes inside it.